### PR TITLE
Add onDeviceUnregisteredCb() callback

### DIFF
--- a/src/Connector.js
+++ b/src/Connector.js
@@ -248,6 +248,7 @@ class Connector {
   async start() {
     this.onDataUpdatedCb = _.noop();
     this.onDataRequestedCb = _.noop();
+    this.onDeviceUnregisteredCb = _.noop();
     this.onDisconnectedCb = _.noop();
     this.onReconnectedCb = _.noop();
 
@@ -317,6 +318,7 @@ class Connector {
   async removeDevice(id) {
     await removeDeviceFromIoTAgent(this.iotAgentUrl, id);
     await removeDeviceFromOrion(this.orionUrl, id);
+    this.onDeviceUnregisteredCb(id);
   }
 
   async listDevices() {
@@ -382,7 +384,7 @@ class Connector {
     }
   }
 
-  // Cloud to device (fog)
+  // Connection callbacks
 
   async onDisconnected(cb) {
     this.onDisconnectedCb = cb;
@@ -392,14 +394,21 @@ class Connector {
     this.onReconnectedCb = cb;
   }
 
-  // cb(event) where event is { id, sensorId }
+  // Cloud to device (fog)
+
+  // cb(event) where event is { id, [ sensorIds ] }
   async onDataRequested(cb) {
     this.onDataRequestedCb = cb;
   }
 
-  // cb(event) where event is { id, [sensorIds] }
+  // cb(event) where event is { id, [{ sensorId, value }] }
   async onDataUpdated(cb) {
     this.onDataUpdatedCb = cb;
+  }
+
+  // cb(event) where event is { id }
+  async onDeviceUnregistered(cb) {
+    this.onDeviceUnregisteredCb = cb;
   }
 }
 


### PR DESCRIPTION
As 'knot-fog-connector-fiware' did not support onDeviceUnregistered(),
the 'device.unregistered' message was not sent to 'knot-fog-connector'.

As a result, devices were not removed from the queue (despite being
removed from the cloud). Add onDeviceUnregisteredCb() call back and
update removeDevice() to use it, after removing the device from
the cloud.