### PR TITLE
Update addDevice

### DIFF
--- a/src/Connector.js
+++ b/src/Connector.js
@@ -364,24 +364,12 @@ class Connector {
 
     const sensors = await Promise.all(schemaList.map(async (schema) => {
       await this.client.subscribe(`/${id}/${schema.sensorId}/cmd`);
-
       return mapSensorToFiware(id, schema);
     }));
 
-    try {
-      await request.post({
-        url, headers, body: { devices: sensors }, json: true,
-      });
-    } catch (err) {
-      /*
-      The 409 error means the request couldn't be completed due to a conflict in
-      respect to the target resource - contextually, a (deviceId, serviceId) pair
-      already exists. However, this occurs when attempting to make changes in a
-      resource which the base connector is already acting upon due to a previous
-      request (e.g. updateSchema). As soon as the request is processed, the error
-      will be gone, without consequences; therefore, it shouldn't cause an interuption.
-      */
-    }
+    await request.post({
+      url, headers, body: { devices: sensors }, json: true,
+    });
   }
 
   // Cloud to device (fog)

--- a/src/Connector.js
+++ b/src/Connector.js
@@ -302,7 +302,7 @@ class Connector {
     };
 
     if (await deviceExistsOnIoTA(this.iotAgentUrl, device.id)) {
-      return;
+      return { id: device.id, token: device.id };
     }
 
     const fiwareDevice = mapDeviceToFiware(device);
@@ -312,6 +312,8 @@ class Connector {
     });
     await createService(this.iotAgentUrl, this.orionUrl, `/device/${device.id}`, device.id, 'sensor');
     await this.client.subscribe(`/default/${device.id}/cmd`);
+
+    return { id: device.id, token: device.id };
   }
 
   async removeDevice(id) {

--- a/src/Connector.js
+++ b/src/Connector.js
@@ -301,7 +301,7 @@ class Connector {
       'fiware-servicepath': '/device',
     };
 
-    if (await deviceExistsOnIoTA(url, device.id)) {
+    if (await deviceExistsOnIoTA(this.iotAgentUrl, device.id)) {
       return;
     }
 


### PR DESCRIPTION
As deviceExistsOnIoTA() concatenates 'url' (parameter) with 'url'
(constant) and both contain '/iot/devices', deviceExists() makes
requests to an invalid url. On top of that, addDevice() returns
nothing; 'knot-fog-connector' expects { device.id, token }.

As a result, deviceExists() always returns 'false' and addDevice()
attempts to register the device multiple times and returns Error 409
-- devices are not registered properly.

Update addDevice() to return the device's id and a token, as well as
pass 'iotAgentUrl' (instead of 'url') to deviceExistsOnIoTA() so that
deviceExists() will make requests to valid url.