### PR TITLE
Add device authentication (close #5)

### DIFF
--- a/src/Connector.js
+++ b/src/Connector.js
@@ -317,6 +317,11 @@ class Connector {
     return { id: device.id, token: device.id };
   }
 
+  // eslint-disable-next-line no-unused-vars
+  async authDevice(id, token) {
+    return deviceExistsOnIoTA(this.iotAgentUrl, id);
+  }
+
   async removeDevice(id) {
     await removeDeviceFromIoTAgent(this.iotAgentUrl, id);
     await removeDeviceFromOrion(this.orionUrl, id);


### PR DESCRIPTION
**What does this pull request achieve?**

This pull request implements the [device authentication command](https://github.com/CESARBR/knot-fog-connector/blob/master/docs/api/amqp.md#device-authentication-status) (closes #5). 

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**

Although this PR ensures compatibility with the latest KNoT version, keep in mind that the current authentication method is not optimal and this approach is mostly justifiable due to task prioritization. A possible alternative is to use the `token`(unused right now) as an asymmetric key of some sort. Challenges in this approach regard FIWARE's absence of support to native authorization/authentication see [this](https://fiware-orion.readthedocs.io/en/master/user/security/index.html). With these thoughts in mind, a better alternative ought to be implemented, in a near future.

**Testing environment:**

- Operating System/Platform: Linux 5.3.13-arch1-1 x86_64 GNU/Linux
- Node: v13.0.1 (via [nvm](https://github.com/nvm-sh/nvm))
- Npm: v6.13.0  (via [nvm](https://github.com/nvm-sh/nvm))
- Docker: 19.03.5-ce, build 633a0ea838
- Docker-compose: version 1.25.0
> Docker-compose and other configuration files can be found [here](https://gist.github.com/lcbm/170fc82440153a8077c04f7941e1b04c). Note that the `docker-compose.yml` file assumes that both *knot-fog-connector* and *cs-biblioteca-service* are in the same parent directory (*e.g.*: ~/home/knot/knot-fog-connector and ~/home/knot/cs-biblioteca-service).

**This is a modified version of the pull request template in [vuejs/vue](https://github.com/vuejs/vue/blob/dev/.github/PULL_REQUEST_TEMPLATE.md)** :smile: 