### PR TITLE
Bump to v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# [3.0.0](https://github.com/CESARBR/knot-fog-connector-fiware/compare/v2.0.0...v3.0.0)
+
+### Features
+
+- Support newer connector API ([CESARBR/knot-fog-connector](https://github.com/CESARBR/knot-fog-connector/releases/tag/v3.0.0)).
+
+### Bug Fixes
+
+- Correct URL when verifying device existance.
+- Verify if data is encoded before publishing.
+- Update lodash version to fix vulnerability issues.
+
+### Improvements
+
+- Remove unnecessary conflict error handling from update schema.
+- Refactor code to improve readability.
+- Listen to connection status.
+
 # [2.0.0](https://github.com/CESARBR/knot-fog-connector-fiware/compare/v1.0.0...v2.0.0)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cesarbr/knot-fog-connector-fiware",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cesarbr/knot-fog-connector-fiware",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "KNoT fog connector with FIWARE",
   "repository": {
     "type": "git",


### PR DESCRIPTION
What does this implement/fix?
---------------------------------------------------
Considering the changes listed in the `CHANGELOG` file, this patch bumps the current version to v3.0.0. The major number was increased since incompatible API changes were made.